### PR TITLE
Added option to specify collection name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 *.iml
 *.project
 *.classpath
+marc/

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'groovy'
     id 'application'
-    id 'com.github.johnrengelman.shadow' version '2.0.2'
+    id 'com.github.johnrengelman.shadow' version '2.0.0'
 }
 
 repositories {
@@ -26,4 +26,3 @@ dependencies {
     compile     'org.apache.logging.log4j:log4j:2.10.0'
     testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
 }
-    

--- a/src/main/groovy/edu/ncsu/lib/dsci/SolrCollectionManager.groovy
+++ b/src/main/groovy/edu/ncsu/lib/dsci/SolrCollectionManager.groovy
@@ -16,14 +16,15 @@ class SolrCollectionManager {
 
     String baseUrl
 
-    String collectionName = "dsci"
+    String collectionName
 
     Collection knownFields = new HashSet()
 
     Map<String, ?> standardFieldDef = Collections.unmodifiableMap([ type: 'text_general', multiValued: true, stored: true, indexed: true ])
 
-    SolrCollectionManager(String solrUrl = "http://localhost:8983/solr") {
+    SolrCollectionManager(String solrUrl = "http://localhost:8983/solr", String collName = "dsci" ) {
         this.baseUrl = solrUrl
+        this.collectionName = collName
     }
 
     private void deleteCollection(SolrClient client) {


### PR DESCRIPTION
@adjam Adam, I added a feature to allow the user to specify the name of the collection that the records are being added to. We needed to have 1 for our Bib records and 1 for our Holding records. If it's not specified, it uses the 'dsci' default. I think it's a fairly useful feature, but feel free to ignore it.
-Dennis